### PR TITLE
Feature: Export of DOIs with download URLs to CSV

### DIFF
--- a/src/db/sumariopmd_client.py
+++ b/src/db/sumariopmd_client.py
@@ -1064,13 +1064,14 @@ class SumarioPMDClient:
         query = """
             SELECT 
                 r.identifier AS doi,
-                f.filename,
-                f.location AS download_url,
-                f.format,
+                f.name AS filename,
+                f.url AS download_url,
+                f.description,
+                f.filemimetype AS format,
                 f.size
             FROM resource r
             INNER JOIN file f ON f.resource_id = r.id
-            ORDER BY r.identifier ASC, f.filename ASC
+            ORDER BY r.identifier ASC, f.name ASC
         """
         
         try:
@@ -1085,6 +1086,7 @@ class SumarioPMDClient:
                             row['doi'],
                             row['filename'],
                             row['download_url'],
+                            row['description'],
                             row['format'],
                             row['size']
                         )

--- a/src/db/sumariopmd_client.py
+++ b/src/db/sumariopmd_client.py
@@ -1002,3 +1002,98 @@ class SumarioPMDClient:
         except pymysql.Error as e:
             logger.error(f"Database error fetching contributor roles: {e}")
             raise DatabaseError(f"Failed to fetch contributor roles: {e}") from e
+    
+    # =========================================================================
+    # File/Download-URL Methods
+    # =========================================================================
+    
+    def fetch_download_urls_for_resource(self, resource_id: int) -> List[Dict[str, Any]]:
+        """
+        Fetch download URLs from file table for a specific resource.
+        
+        Args:
+            resource_id: Resource ID from resource table
+            
+        Returns:
+            List of file dictionaries with keys:
+            - filename: str
+            - location: str (download URL)
+            - format: str (file format)
+            - size: int (file size in bytes)
+            
+        Raises:
+            DatabaseError: If query fails
+        """
+        query = """
+            SELECT 
+                filename,
+                location,
+                format,
+                size
+            FROM file
+            WHERE resource_id = %s
+            ORDER BY filename ASC
+        """
+        
+        try:
+            with self.get_connection() as conn:
+                with conn.cursor() as cursor:
+                    cursor.execute(query, (resource_id,))
+                    files = cursor.fetchall()
+                    
+                    logger.info(f"Fetched {len(files)} files for resource_id {resource_id}")
+                    return files
+                    
+        except pymysql.Error as e:
+            logger.error(f"Database error fetching files for resource_id {resource_id}: {e}")
+            raise DatabaseError(f"Failed to fetch files: {e}") from e
+    
+    def fetch_all_dois_with_downloads(self) -> List[Tuple[str, str, str, str, int]]:
+        """
+        Fetch all DOIs with their download URLs from file table.
+        
+        Returns one row per file, so a DOI with multiple files will appear multiple times.
+        
+        Returns:
+            List of tuples containing:
+            (DOI, Filename, Download_URL, Format, Size_Bytes)
+            
+        Raises:
+            DatabaseError: If query fails
+        """
+        query = """
+            SELECT 
+                r.identifier AS doi,
+                f.filename,
+                f.location AS download_url,
+                f.format,
+                f.size
+            FROM resource r
+            INNER JOIN file f ON f.resource_id = r.id
+            ORDER BY r.identifier ASC, f.filename ASC
+        """
+        
+        try:
+            with self.get_connection() as conn:
+                with conn.cursor() as cursor:
+                    cursor.execute(query)
+                    results = cursor.fetchall()
+                    
+                    # Convert to list of tuples
+                    dois_files = [
+                        (
+                            row['doi'],
+                            row['filename'],
+                            row['download_url'],
+                            row['format'],
+                            row['size']
+                        )
+                        for row in results
+                    ]
+                    
+                    logger.info(f"Fetched {len(dois_files)} file entries from database")
+                    return dois_files
+                    
+        except pymysql.Error as e:
+            logger.error(f"Database error fetching DOIs with downloads: {e}")
+            raise DatabaseError(f"Failed to fetch DOIs with downloads: {e}") from e

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -2950,8 +2950,12 @@ class MainWindow(QMainWindow):
         
         self._log(f"[OK] {len(dois_files)} Datei-Einträge abgerufen")
         
-        # File dialog
-        default_filename = f"dois_download_urls_{datetime.now():%Y%m%d_%H%M%S}.csv"
+        # Use current username if available, otherwise use generic name
+        if self._current_username:
+            default_filename = f"{self._current_username}_download_urls.csv"
+        else:
+            default_filename = "download_urls.csv"
+        
         filepath, _ = QFileDialog.getSaveFileName(
             self,
             "CSV-Datei speichern",

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -562,6 +562,20 @@ class MainWindow(QMainWindow):
         contributors_group.setLayout(contributors_layout)
         layout.addWidget(contributors_group)
         
+        # GroupBox 5: Download URLs
+        downloads_group = QGroupBox("📦 Download-URLs")
+        downloads_layout = QVBoxLayout()
+        downloads_layout.setSpacing(10)
+        
+        # Buttons for download URLs workflow
+        self.export_download_urls_btn = QPushButton("📥 DOIs und Download-URLs exportieren")
+        self.export_download_urls_btn.setMinimumHeight(40)
+        self.export_download_urls_btn.clicked.connect(self._on_export_download_urls_clicked)
+        downloads_layout.addWidget(self.export_download_urls_btn)
+        
+        downloads_group.setLayout(downloads_layout)
+        layout.addWidget(downloads_group)
+        
         # Progress bar
         self.progress_bar = QProgressBar()
         self.progress_bar.setVisible(False)
@@ -2851,6 +2865,140 @@ class MainWindow(QMainWindow):
         except Exception as e:
             self._log(f"[WARNUNG] Log-Datei konnte nicht erstellt werden: {str(e)}")
     
+    # ==================== DOWNLOAD URLs METHODS ====================
+    
+    def _on_export_download_urls_clicked(self):
+        """Handle export download URLs button click."""
+        # Check if database is configured
+        settings = QSettings("GFZ", "GROBI")
+        db_enabled = settings.value("database/enabled", False, type=bool)
+        
+        if not db_enabled:
+            QMessageBox.warning(
+                self,
+                "Datenbank nicht konfiguriert",
+                "Die Datenbank-Verbindung ist nicht aktiviert.\n\n"
+                "Bitte konfiguriere die Datenbank-Verbindung in den Einstellungen "
+                "(Einstellungen → Datenbank-Verbindung)."
+            )
+            return
+        
+        # Load DB credentials
+        from src.utils.credential_manager import load_db_credentials
+        
+        db_creds = load_db_credentials()
+        if not db_creds:
+            QMessageBox.warning(
+                self,
+                "Keine DB-Credentials",
+                "Keine Datenbank-Zugangsdaten gespeichert.\n\n"
+                "Bitte konfiguriere die Datenbank in den Einstellungen."
+            )
+            return
+        
+        # Start worker
+        self._start_download_url_fetch(db_creds)
+    
+    def _start_download_url_fetch(self, db_creds: dict):
+        """Start worker to fetch DOIs with download URLs from database."""
+        self._log("Starte Download-URL Export...")
+        
+        # Import worker
+        from src.workers.download_url_fetch_worker import DownloadURLFetchWorker
+        
+        # Create worker
+        self.download_url_worker = DownloadURLFetchWorker(
+            db_host=db_creds['host'],
+            db_name=db_creds['database'],
+            db_user=db_creds['username'],
+            db_password=db_creds['password']
+        )
+        
+        # Connect signals
+        self.download_url_worker.progress.connect(self._log)
+        self.download_url_worker.finished.connect(self._on_download_urls_fetched)
+        self.download_url_worker.error.connect(self._on_download_urls_error)
+        
+        # Create thread
+        self.download_url_thread = QThread()
+        self.download_url_worker.moveToThread(self.download_url_thread)
+        
+        # Connect thread signals
+        self.download_url_thread.started.connect(self.download_url_worker.run)
+        self.download_url_worker.finished.connect(self.download_url_thread.quit)
+        self.download_url_worker.error.connect(self.download_url_thread.quit)
+        
+        # Clean up after worker finishes or errors
+        self.download_url_worker.finished.connect(self.download_url_worker.deleteLater)
+        self.download_url_worker.error.connect(self.download_url_worker.deleteLater)
+        
+        # Clean up thread when it finishes
+        self.download_url_thread.finished.connect(self.download_url_thread.deleteLater)
+        self.download_url_thread.finished.connect(self._cleanup_download_url_worker)
+        
+        # Start thread
+        self.download_url_thread.start()
+        
+        # Disable button during fetch
+        self.export_download_urls_btn.setEnabled(False)
+        self.progress_bar.setVisible(True)
+    
+    def _on_download_urls_fetched(self, dois_files):
+        """Called when DOIs with download URLs have been fetched."""
+        from PySide6.QtWidgets import QFileDialog
+        from src.utils.csv_exporter import export_dois_download_urls
+        
+        self._log(f"[OK] {len(dois_files)} Datei-Einträge abgerufen")
+        
+        # File dialog
+        default_filename = f"dois_download_urls_{datetime.now():%Y%m%d_%H%M%S}.csv"
+        filepath, _ = QFileDialog.getSaveFileName(
+            self,
+            "CSV-Datei speichern",
+            default_filename,
+            "CSV Files (*.csv)"
+        )
+        
+        if filepath:
+            try:
+                export_dois_download_urls(dois_files, filepath)
+                
+                # Count unique DOIs
+                unique_dois = len(set(doi for doi, _, _, _, _ in dois_files))
+                
+                self._log(f"[OK] CSV-Datei gespeichert: {filepath}")
+                QMessageBox.information(
+                    self,
+                    "Export erfolgreich",
+                    f"DOIs und Download-URLs wurden exportiert:\n\n"
+                    f"Datei: {Path(filepath).name}\n"
+                    f"DOIs: {unique_dois}\n"
+                    f"Dateien: {len(dois_files)}"
+                )
+            except Exception as e:
+                self._log(f"[FEHLER] CSV-Export fehlgeschlagen: {e}")
+                QMessageBox.critical(
+                    self,
+                    "Fehler",
+                    f"CSV-Export fehlgeschlagen:\n{e}"
+                )
+    
+    def _on_download_urls_error(self, error_msg: str):
+        """Called when fetch failed."""
+        self._log(f"[FEHLER] {error_msg}")
+        QMessageBox.critical(self, "Fehler", error_msg)
+    
+    def _cleanup_download_url_worker(self):
+        """Clean up worker and thread."""
+        self.progress_bar.setVisible(False)
+        self.export_download_urls_btn.setEnabled(True)
+        
+        # Reset references (objects are deleted via deleteLater)
+        self.download_url_thread = None
+        self.download_url_worker = None
+        
+        self._log("Bereit für nächsten Vorgang.")
+    
     def closeEvent(self, event):
         """
         Handle window close event.
@@ -2907,5 +3055,11 @@ class MainWindow(QMainWindow):
                 self.contributors_update_worker.stop()
             self.contributors_update_thread.quit()
             self.contributors_update_thread.wait(3000)  # Wait max 3 seconds
+        
+        # If download URL thread is running, wait for it to finish
+        if hasattr(self, 'download_url_thread') and self.download_url_thread is not None and self.download_url_thread.isRunning():
+            self._log("Warte auf Abschluss des Download-URL Exports...")
+            self.download_url_thread.quit()
+            self.download_url_thread.wait(3000)  # Wait max 3 seconds
         
         event.accept()

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -2964,7 +2964,7 @@ class MainWindow(QMainWindow):
                 export_dois_download_urls(dois_files, filepath)
                 
                 # Count unique DOIs
-                unique_dois = len(set(doi for doi, _, _, _, _ in dois_files))
+                unique_dois = len(set(doi for doi, _, _, _, _, _ in dois_files))
                 
                 self._log(f"[OK] CSV-Datei gespeichert: {filepath}")
                 QMessageBox.information(

--- a/src/utils/csv_exporter.py
+++ b/src/utils/csv_exporter.py
@@ -411,6 +411,51 @@ def export_dois_with_contributors_to_csv(
         raise CSVExportError(error_msg)
 
 
+def export_dois_download_urls(
+    dois_files: List[Tuple[str, str, str, str, int]], 
+    filepath: str
+) -> None:
+    """
+    Export DOIs with download URLs to CSV.
+    
+    Args:
+        dois_files: List of (DOI, Filename, Download_URL, Format, Size_Bytes) tuples
+        filepath: Output CSV file path
+        
+    Raises:
+        CSVExportError: If file cannot be written
+    """
+    logger.info(f"Exporting {len(dois_files)} file entries to {filepath}")
+    
+    try:
+        with open(filepath, 'w', newline='', encoding='utf-8') as csvfile:
+            writer = csv.writer(csvfile)
+            
+            # Header
+            writer.writerow(['DOI', 'Filename', 'Download_URL', 'Format', 'Size_Bytes'])
+            
+            # Data rows
+            for doi, filename, url, format_str, size in dois_files:
+                writer.writerow([doi, filename, url, format_str, size])
+        
+        logger.info(f"Successfully exported {len(dois_files)} file entries to {filepath}")
+        
+    except PermissionError as e:
+        error_msg = f"Keine Berechtigung zum Schreiben der Datei: {filepath}"
+        logger.error(f"Permission error writing file: {e}")
+        raise CSVExportError(error_msg)
+    
+    except OSError as e:
+        error_msg = f"Die CSV-Datei konnte nicht gespeichert werden: {str(e)}"
+        logger.error(f"OS error writing file: {e}")
+        raise CSVExportError(error_msg)
+    
+    except Exception as e:
+        error_msg = f"Unerwarteter Fehler beim Speichern der CSV-Datei: {str(e)}"
+        logger.error(f"Unexpected error: {e}")
+        raise CSVExportError(error_msg)
+
+
 def validate_csv_format(filepath: str) -> bool:
     """
     Validate that a CSV file has the correct format.

--- a/src/utils/csv_exporter.py
+++ b/src/utils/csv_exporter.py
@@ -412,14 +412,14 @@ def export_dois_with_contributors_to_csv(
 
 
 def export_dois_download_urls(
-    dois_files: List[Tuple[str, str, str, str, int]], 
+    dois_files: List[Tuple[str, str, str, str, str, int]], 
     filepath: str
 ) -> None:
     """
     Export DOIs with download URLs to CSV.
     
     Args:
-        dois_files: List of (DOI, Filename, Download_URL, Format, Size_Bytes) tuples
+        dois_files: List of (DOI, Filename, Download_URL, Description, Format, Size_Bytes) tuples
         filepath: Output CSV file path
         
     Raises:
@@ -432,11 +432,11 @@ def export_dois_download_urls(
             writer = csv.writer(csvfile)
             
             # Header
-            writer.writerow(['DOI', 'Filename', 'Download_URL', 'Format', 'Size_Bytes'])
+            writer.writerow(['DOI', 'Filename', 'Download_URL', 'Description', 'Format', 'Size_Bytes'])
             
             # Data rows
-            for doi, filename, url, format_str, size in dois_files:
-                writer.writerow([doi, filename, url, format_str, size])
+            for doi, filename, url, description, format_str, size in dois_files:
+                writer.writerow([doi, filename, url, description, format_str, size])
         
         logger.info(f"Successfully exported {len(dois_files)} file entries to {filepath}")
         

--- a/src/workers/download_url_fetch_worker.py
+++ b/src/workers/download_url_fetch_worker.py
@@ -1,0 +1,85 @@
+"""Worker for fetching DOIs with download URLs from database."""
+
+import logging
+from typing import List, Tuple
+from PySide6.QtCore import QObject, Signal
+
+from src.db.sumariopmd_client import SumarioPMDClient, DatabaseError, ConnectionError as DBConnectionError
+
+logger = logging.getLogger(__name__)
+
+
+class DownloadURLFetchWorker(QObject):
+    """Worker for fetching DOIs with download URLs in a separate thread."""
+    
+    # Signals
+    progress = Signal(str)  # Progress messages
+    finished = Signal(list)  # List of (DOI, Filename, URL, Format, Size) tuples
+    error = Signal(str)     # Error message
+    
+    def __init__(self, db_host: str, db_name: str, db_user: str, db_password: str):
+        """
+        Initialize worker with database credentials.
+        
+        Args:
+            db_host: Database host
+            db_name: Database name
+            db_user: Database username
+            db_password: Database password
+        """
+        super().__init__()
+        self.db_host = db_host
+        self.db_name = db_name
+        self.db_user = db_user
+        self.db_password = db_password
+    
+    def run(self):
+        """Fetch DOIs with download URLs from database."""
+        try:
+            self.progress.emit("Verbindung zur Datenbank wird hergestellt...")
+            
+            # Initialize database client
+            db_client = SumarioPMDClient(
+                host=self.db_host,
+                database=self.db_name,
+                username=self.db_user,
+                password=self.db_password
+            )
+            
+            # Test connection
+            success, message = db_client.test_connection()
+            if not success:
+                self.error.emit(f"Datenbankverbindung fehlgeschlagen: {message}")
+                return
+            
+            self.progress.emit("DOIs und Download-URLs werden abgerufen...")
+            
+            # Fetch all DOIs with download URLs
+            dois_files = db_client.fetch_all_dois_with_downloads()
+            
+            if not dois_files:
+                self.error.emit("Keine DOIs mit Download-URLs gefunden.")
+                return
+            
+            # Count unique DOIs
+            unique_dois = len(set(doi for doi, _, _, _, _ in dois_files))
+            self.progress.emit(
+                f"[OK] {len(dois_files)} Dateien für {unique_dois} DOIs gefunden"
+            )
+            
+            self.finished.emit(dois_files)
+            
+        except DBConnectionError as e:
+            error_msg = f"Datenbankverbindung fehlgeschlagen: {str(e)}"
+            logger.error(error_msg)
+            self.error.emit(error_msg)
+            
+        except DatabaseError as e:
+            error_msg = f"Datenbankfehler: {str(e)}"
+            logger.error(error_msg)
+            self.error.emit(error_msg)
+            
+        except Exception as e:
+            error_msg = f"Unerwarteter Fehler: {str(e)}"
+            logger.error(error_msg, exc_info=True)
+            self.error.emit(error_msg)

--- a/src/workers/download_url_fetch_worker.py
+++ b/src/workers/download_url_fetch_worker.py
@@ -14,7 +14,7 @@ class DownloadURLFetchWorker(QObject):
     
     # Signals
     progress = Signal(str)  # Progress messages
-    finished = Signal(list)  # List of (DOI, Filename, URL, Format, Size) tuples
+    finished = Signal(list)  # List of (DOI, Filename, URL, Description, Format, Size) tuples
     error = Signal(str)     # Error message
     
     def __init__(self, db_host: str, db_name: str, db_user: str, db_password: str):
@@ -62,7 +62,7 @@ class DownloadURLFetchWorker(QObject):
                 return
             
             # Count unique DOIs
-            unique_dois = len(set(doi for doi, _, _, _, _ in dois_files))
+            unique_dois = len(set(doi for doi, _, _, _, _, _ in dois_files))
             self.progress.emit(
                 f"[OK] {len(dois_files)} Dateien für {unique_dois} DOIs gefunden"
             )

--- a/tests/test_csv_export_download_urls.py
+++ b/tests/test_csv_export_download_urls.py
@@ -13,9 +13,9 @@ class TestExportDOIsDownloadURLs:
     def test_export_success(self, tmp_path):
         """Test successful export of DOIs with download URLs."""
         data = [
-            ("10.5880/GFZ.1", "data.zip", "https://download.gfz.de/data.zip", "ZIP", 1048576),
-            ("10.5880/GFZ.1", "metadata.xml", "https://download.gfz.de/meta.xml", "XML", 2048),
-            ("10.5880/GFZ.2", "dataset.nc", "https://download.gfz.de/data.nc", "NetCDF", 5242880),
+            ("10.5880/GFZ.1", "data.zip", "https://download.gfz.de/data.zip", "Download data and description", "ZIP", 1048576),
+            ("10.5880/GFZ.1", "metadata.xml", "https://download.gfz.de/meta.xml", "Metadata file", "XML", 2048),
+            ("10.5880/GFZ.2", "dataset.nc", "https://download.gfz.de/data.nc", "NetCDF dataset", "NetCDF", 5242880),
         ]
         
         filepath = tmp_path / "dois_downloads.csv"
@@ -30,13 +30,13 @@ class TestExportDOIsDownloadURLs:
             rows = list(reader)
         
         # Check header
-        assert rows[0] == ['DOI', 'Filename', 'Download_URL', 'Format', 'Size_Bytes']
+        assert rows[0] == ['DOI', 'Filename', 'Download_URL', 'Description', 'Format', 'Size_Bytes']
         
         # Check data rows
         assert len(rows) == 4  # Header + 3 data rows
-        assert rows[1] == ["10.5880/GFZ.1", "data.zip", "https://download.gfz.de/data.zip", "ZIP", "1048576"]
-        assert rows[2] == ["10.5880/GFZ.1", "metadata.xml", "https://download.gfz.de/meta.xml", "XML", "2048"]
-        assert rows[3] == ["10.5880/GFZ.2", "dataset.nc", "https://download.gfz.de/data.nc", "NetCDF", "5242880"]
+        assert rows[1] == ["10.5880/GFZ.1", "data.zip", "https://download.gfz.de/data.zip", "Download data and description", "ZIP", "1048576"]
+        assert rows[2] == ["10.5880/GFZ.1", "metadata.xml", "https://download.gfz.de/meta.xml", "Metadata file", "XML", "2048"]
+        assert rows[3] == ["10.5880/GFZ.2", "dataset.nc", "https://download.gfz.de/data.nc", "NetCDF dataset", "NetCDF", "5242880"]
     
     def test_export_empty_list(self, tmp_path):
         """Test export with empty data list."""
@@ -49,12 +49,12 @@ class TestExportDOIsDownloadURLs:
         
         # Only header
         assert len(rows) == 1
-        assert rows[0] == ['DOI', 'Filename', 'Download_URL', 'Format', 'Size_Bytes']
+        assert rows[0] == ['DOI', 'Filename', 'Download_URL', 'Description', 'Format', 'Size_Bytes']
     
     def test_export_special_characters(self, tmp_path):
         """Test export with special characters in filenames and URLs."""
         data = [
-            ("10.5880/GFZ.ü.ä.ö", "dätä file.zip", "https://example.com/file?param=val&other=123", "ZIP", 1024),
+            ("10.5880/GFZ.ü.ä.ö", "dätä file.zip", "https://example.com/file?param=val&other=123", "Special chars test", "ZIP", 1024),
         ]
         
         filepath = tmp_path / "special.csv"
@@ -68,6 +68,7 @@ class TestExportDOIsDownloadURLs:
             "10.5880/GFZ.ü.ä.ö",
             "dätä file.zip",
             "https://example.com/file?param=val&other=123",
+            "Special chars test",
             "ZIP",
             "1024"
         ]
@@ -75,7 +76,7 @@ class TestExportDOIsDownloadURLs:
     def test_export_large_file_sizes(self, tmp_path):
         """Test export with large file sizes."""
         data = [
-            ("10.5880/GFZ.1", "huge.tar.gz", "https://example.com/huge.tar.gz", "TAR.GZ", 10737418240),  # 10 GB
+            ("10.5880/GFZ.1", "huge.tar.gz", "https://example.com/huge.tar.gz", "Large file", "TAR.GZ", 10737418240),  # 10 GB
         ]
         
         filepath = tmp_path / "large.csv"
@@ -85,15 +86,15 @@ class TestExportDOIsDownloadURLs:
             reader = csv.reader(f)
             rows = list(reader)
         
-        assert rows[1][4] == "10737418240"
+        assert rows[1][5] == "10737418240"
     
     def test_export_multiple_files_per_doi(self, tmp_path):
         """Test export where DOIs have multiple files (realistic scenario)."""
         data = [
-            ("10.5880/GFZ.1", "file1.zip", "https://example.com/file1.zip", "ZIP", 1024),
-            ("10.5880/GFZ.1", "file2.zip", "https://example.com/file2.zip", "ZIP", 2048),
-            ("10.5880/GFZ.1", "file3.xml", "https://example.com/file3.xml", "XML", 512),
-            ("10.5880/GFZ.2", "data.nc", "https://example.com/data.nc", "NetCDF", 4096),
+            ("10.5880/GFZ.1", "file1.zip", "https://example.com/file1.zip", "First file", "ZIP", 1024),
+            ("10.5880/GFZ.1", "file2.zip", "https://example.com/file2.zip", "Second file", "ZIP", 2048),
+            ("10.5880/GFZ.1", "file3.xml", "https://example.com/file3.xml", "Metadata", "XML", 512),
+            ("10.5880/GFZ.2", "data.nc", "https://example.com/data.nc", "Dataset", "NetCDF", 4096),
         ]
         
         filepath = tmp_path / "multiple.csv"
@@ -129,7 +130,7 @@ class TestExportDOIsDownloadURLs:
         os.chmod(readonly_dir, 0o444)
         
         filepath = readonly_dir / "test.csv"
-        data = [("10.5880/GFZ.1", "file.zip", "https://example.com/file.zip", "ZIP", 1024)]
+        data = [("10.5880/GFZ.1", "file.zip", "https://example.com/file.zip", "Test file", "ZIP", 1024)]
         
         try:
             with pytest.raises(CSVExportError, match="Keine Berechtigung|konnte nicht gespeichert werden"):
@@ -140,7 +141,7 @@ class TestExportDOIsDownloadURLs:
     
     def test_export_invalid_path(self):
         """Test handling of invalid file paths."""
-        data = [("10.5880/GFZ.1", "file.zip", "https://example.com/file.zip", "ZIP", 1024)]
+        data = [("10.5880/GFZ.1", "file.zip", "https://example.com/file.zip", "Test file", "ZIP", 1024)]
         
         # Invalid path (assuming this doesn't exist on any system)
         invalid_path = "/nonexistent/path/with/many/levels/file.csv"
@@ -151,8 +152,8 @@ class TestExportDOIsDownloadURLs:
     def test_export_utf8_encoding(self, tmp_path):
         """Test that files are properly encoded in UTF-8."""
         data = [
-            ("10.5880/GFZ.1", "日本語.zip", "https://example.com/日本語.zip", "ZIP", 1024),
-            ("10.5880/GFZ.2", "Файл.tar", "https://example.com/Файл.tar", "TAR", 2048),
+            ("10.5880/GFZ.1", "日本語.zip", "https://example.com/日本語.zip", "Japanese file", "ZIP", 1024),
+            ("10.5880/GFZ.2", "Файл.tar", "https://example.com/Файл.tar", "Russian file", "TAR", 2048),
         ]
         
         filepath = tmp_path / "utf8.csv"

--- a/tests/test_csv_export_download_urls.py
+++ b/tests/test_csv_export_download_urls.py
@@ -1,0 +1,166 @@
+"""Tests for CSV export of DOIs with download URLs."""
+
+import pytest
+import csv
+from pathlib import Path
+
+from src.utils.csv_exporter import export_dois_download_urls, CSVExportError
+
+
+class TestExportDOIsDownloadURLs:
+    """Tests for export_dois_download_urls function."""
+    
+    def test_export_success(self, tmp_path):
+        """Test successful export of DOIs with download URLs."""
+        data = [
+            ("10.5880/GFZ.1", "data.zip", "https://download.gfz.de/data.zip", "ZIP", 1048576),
+            ("10.5880/GFZ.1", "metadata.xml", "https://download.gfz.de/meta.xml", "XML", 2048),
+            ("10.5880/GFZ.2", "dataset.nc", "https://download.gfz.de/data.nc", "NetCDF", 5242880),
+        ]
+        
+        filepath = tmp_path / "dois_downloads.csv"
+        export_dois_download_urls(data, str(filepath))
+        
+        # Verify file exists
+        assert filepath.exists()
+        
+        # Verify content
+        with open(filepath, 'r', encoding='utf-8') as f:
+            reader = csv.reader(f)
+            rows = list(reader)
+        
+        # Check header
+        assert rows[0] == ['DOI', 'Filename', 'Download_URL', 'Format', 'Size_Bytes']
+        
+        # Check data rows
+        assert len(rows) == 4  # Header + 3 data rows
+        assert rows[1] == ["10.5880/GFZ.1", "data.zip", "https://download.gfz.de/data.zip", "ZIP", "1048576"]
+        assert rows[2] == ["10.5880/GFZ.1", "metadata.xml", "https://download.gfz.de/meta.xml", "XML", "2048"]
+        assert rows[3] == ["10.5880/GFZ.2", "dataset.nc", "https://download.gfz.de/data.nc", "NetCDF", "5242880"]
+    
+    def test_export_empty_list(self, tmp_path):
+        """Test export with empty data list."""
+        filepath = tmp_path / "empty.csv"
+        export_dois_download_urls([], str(filepath))
+        
+        with open(filepath, 'r', encoding='utf-8') as f:
+            reader = csv.reader(f)
+            rows = list(reader)
+        
+        # Only header
+        assert len(rows) == 1
+        assert rows[0] == ['DOI', 'Filename', 'Download_URL', 'Format', 'Size_Bytes']
+    
+    def test_export_special_characters(self, tmp_path):
+        """Test export with special characters in filenames and URLs."""
+        data = [
+            ("10.5880/GFZ.ü.ä.ö", "dätä file.zip", "https://example.com/file?param=val&other=123", "ZIP", 1024),
+        ]
+        
+        filepath = tmp_path / "special.csv"
+        export_dois_download_urls(data, str(filepath))
+        
+        with open(filepath, 'r', encoding='utf-8') as f:
+            reader = csv.reader(f)
+            rows = list(reader)
+        
+        assert rows[1] == [
+            "10.5880/GFZ.ü.ä.ö",
+            "dätä file.zip",
+            "https://example.com/file?param=val&other=123",
+            "ZIP",
+            "1024"
+        ]
+    
+    def test_export_large_file_sizes(self, tmp_path):
+        """Test export with large file sizes."""
+        data = [
+            ("10.5880/GFZ.1", "huge.tar.gz", "https://example.com/huge.tar.gz", "TAR.GZ", 10737418240),  # 10 GB
+        ]
+        
+        filepath = tmp_path / "large.csv"
+        export_dois_download_urls(data, str(filepath))
+        
+        with open(filepath, 'r', encoding='utf-8') as f:
+            reader = csv.reader(f)
+            rows = list(reader)
+        
+        assert rows[1][4] == "10737418240"
+    
+    def test_export_multiple_files_per_doi(self, tmp_path):
+        """Test export where DOIs have multiple files (realistic scenario)."""
+        data = [
+            ("10.5880/GFZ.1", "file1.zip", "https://example.com/file1.zip", "ZIP", 1024),
+            ("10.5880/GFZ.1", "file2.zip", "https://example.com/file2.zip", "ZIP", 2048),
+            ("10.5880/GFZ.1", "file3.xml", "https://example.com/file3.xml", "XML", 512),
+            ("10.5880/GFZ.2", "data.nc", "https://example.com/data.nc", "NetCDF", 4096),
+        ]
+        
+        filepath = tmp_path / "multiple.csv"
+        export_dois_download_urls(data, str(filepath))
+        
+        with open(filepath, 'r', encoding='utf-8') as f:
+            reader = csv.reader(f)
+            rows = list(reader)
+        
+        # 4 data rows + 1 header
+        assert len(rows) == 5
+        
+        # First DOI appears 3 times
+        doi_1_count = sum(1 for row in rows[1:] if row[0] == "10.5880/GFZ.1")
+        assert doi_1_count == 3
+        
+        # Second DOI appears once
+        doi_2_count = sum(1 for row in rows[1:] if row[0] == "10.5880/GFZ.2")
+        assert doi_2_count == 1
+    
+    def test_export_permission_error(self, tmp_path):
+        """Test handling of permission errors."""
+        import sys
+        import os
+        
+        # Skip on Windows as file permissions work differently
+        if sys.platform == "win32":
+            pytest.skip("Permission tests are unreliable on Windows")
+        
+        # Create a read-only directory
+        readonly_dir = tmp_path / "readonly"
+        readonly_dir.mkdir()
+        os.chmod(readonly_dir, 0o444)
+        
+        filepath = readonly_dir / "test.csv"
+        data = [("10.5880/GFZ.1", "file.zip", "https://example.com/file.zip", "ZIP", 1024)]
+        
+        try:
+            with pytest.raises(CSVExportError, match="Keine Berechtigung|konnte nicht gespeichert werden"):
+                export_dois_download_urls(data, str(filepath))
+        finally:
+            # Restore write permissions for cleanup
+            os.chmod(readonly_dir, 0o755)
+    
+    def test_export_invalid_path(self):
+        """Test handling of invalid file paths."""
+        data = [("10.5880/GFZ.1", "file.zip", "https://example.com/file.zip", "ZIP", 1024)]
+        
+        # Invalid path (assuming this doesn't exist on any system)
+        invalid_path = "/nonexistent/path/with/many/levels/file.csv"
+        
+        with pytest.raises(CSVExportError):
+            export_dois_download_urls(data, invalid_path)
+    
+    def test_export_utf8_encoding(self, tmp_path):
+        """Test that files are properly encoded in UTF-8."""
+        data = [
+            ("10.5880/GFZ.1", "日本語.zip", "https://example.com/日本語.zip", "ZIP", 1024),
+            ("10.5880/GFZ.2", "Файл.tar", "https://example.com/Файл.tar", "TAR", 2048),
+        ]
+        
+        filepath = tmp_path / "utf8.csv"
+        export_dois_download_urls(data, str(filepath))
+        
+        # Verify UTF-8 encoding
+        with open(filepath, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        assert "日本語" in content
+        assert "Файл" in content

--- a/tests/test_download_url_fetch_worker.py
+++ b/tests/test_download_url_fetch_worker.py
@@ -42,8 +42,8 @@ class TestDownloadURLFetchWorker:
         )
         
         mock_data = [
-            ('10.5880/GFZ.1', 'data.zip', 'https://example.com/data.zip', 'ZIP', 1024),
-            ('10.5880/GFZ.2', 'file.nc', 'https://example.com/file.nc', 'NetCDF', 2048)
+            ('10.5880/GFZ.1', 'data.zip', 'https://example.com/data.zip', 'Download data file', 'ZIP', 1024),
+            ('10.5880/GFZ.2', 'file.nc', 'https://example.com/file.nc', 'Metadata file', 'NetCDF', 2048)
         ]
         
         with patch('src.workers.download_url_fetch_worker.SumarioPMDClient') as mock_client_class:

--- a/tests/test_download_url_fetch_worker.py
+++ b/tests/test_download_url_fetch_worker.py
@@ -1,0 +1,166 @@
+"""Tests for DownloadURLFetchWorker."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from PySide6.QtWidgets import QApplication
+
+from src.workers.download_url_fetch_worker import DownloadURLFetchWorker
+from src.db.sumariopmd_client import DatabaseError, ConnectionError as DBConnectionError
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    """Create QApplication instance for tests."""
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+class TestDownloadURLFetchWorker:
+    """Tests for DownloadURLFetchWorker class."""
+    
+    def test_worker_initialization(self, qapp):
+        """Test worker initialization with credentials."""
+        worker = DownloadURLFetchWorker(
+            db_host="test.host",
+            db_name="test_db",
+            db_user="test_user",
+            db_password="test_pass"
+        )
+        
+        assert worker.db_host == "test.host"
+        assert worker.db_name == "test_db"
+        assert worker.db_user == "test_user"
+        assert worker.db_password == "test_pass"
+    
+    def test_worker_successful_fetch(self, qapp, qtbot):
+        """Test successful DOI+download URL fetch."""
+        worker = DownloadURLFetchWorker(
+            db_host="test.host",
+            db_name="test_db",
+            db_user="test_user",
+            db_password="test_pass"
+        )
+        
+        mock_data = [
+            ('10.5880/GFZ.1', 'data.zip', 'https://example.com/data.zip', 'ZIP', 1024),
+            ('10.5880/GFZ.2', 'file.nc', 'https://example.com/file.nc', 'NetCDF', 2048)
+        ]
+        
+        with patch('src.workers.download_url_fetch_worker.SumarioPMDClient') as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.test_connection.return_value = (True, "Connected")
+            mock_client.fetch_all_dois_with_downloads.return_value = mock_data
+            mock_client_class.return_value = mock_client
+            
+            # Connect signal spy
+            with qtbot.waitSignal(worker.finished, timeout=2000) as blocker:
+                worker.run()
+            
+            # Verify signal data - finished signal contains the list of tuples
+            result_data = blocker.args[0]
+            assert len(result_data) == 2
+            assert result_data[0][0] == '10.5880/GFZ.1'
+            assert result_data[1][0] == '10.5880/GFZ.2'
+    
+    def test_worker_connection_failure(self, qapp, qtbot):
+        """Test handling of connection failure."""
+        worker = DownloadURLFetchWorker(
+            db_host="test.host",
+            db_name="test_db",
+            db_user="test_user",
+            db_password="test_pass"
+        )
+        
+        with patch('src.workers.download_url_fetch_worker.SumarioPMDClient') as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.test_connection.return_value = (False, "Connection refused")
+            mock_client_class.return_value = mock_client
+            
+            # Connect signal spy
+            with qtbot.waitSignal(worker.error, timeout=2000) as blocker:
+                worker.run()
+            
+            # Verify error message
+            assert "Datenbankverbindung fehlgeschlagen" in blocker.args[0]
+    
+    def test_worker_no_data(self, qapp, qtbot):
+        """Test handling when no DOIs with files are found."""
+        worker = DownloadURLFetchWorker(
+            db_host="test.host",
+            db_name="test_db",
+            db_user="test_user",
+            db_password="test_pass"
+        )
+        
+        with patch('src.workers.download_url_fetch_worker.SumarioPMDClient') as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.test_connection.return_value = (True, "Connected")
+            mock_client.fetch_all_dois_with_downloads.return_value = []
+            mock_client_class.return_value = mock_client
+            
+            # Connect signal spy
+            with qtbot.waitSignal(worker.error, timeout=2000) as blocker:
+                worker.run()
+            
+            # Verify error message
+            assert "Keine DOIs mit Download-URLs gefunden" in blocker.args[0]
+    
+    def test_worker_database_error(self, qapp, qtbot):
+        """Test handling of database errors during fetch."""
+        worker = DownloadURLFetchWorker(
+            db_host="test.host",
+            db_name="test_db",
+            db_user="test_user",
+            db_password="test_pass"
+        )
+        
+        with patch('src.workers.download_url_fetch_worker.SumarioPMDClient') as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.test_connection.return_value = (True, "Connected")
+            mock_client.fetch_all_dois_with_downloads.side_effect = DatabaseError("Query failed")
+            mock_client_class.return_value = mock_client
+            
+            # Connect signal spy
+            with qtbot.waitSignal(worker.error, timeout=2000) as blocker:
+                worker.run()
+            
+            # Verify error message
+            assert "Datenbankfehler" in blocker.args[0]
+    
+    def test_worker_connection_error(self, qapp, qtbot):
+        """Test handling of connection errors."""
+        worker = DownloadURLFetchWorker(
+            db_host="test.host",
+            db_name="test_db",
+            db_user="test_user",
+            db_password="test_pass"
+        )
+        
+        with patch('src.workers.download_url_fetch_worker.SumarioPMDClient') as mock_client_class:
+            mock_client_class.side_effect = DBConnectionError("Cannot connect")
+            
+            # Connect signal spy
+            with qtbot.waitSignal(worker.error, timeout=2000) as blocker:
+                worker.run()
+            
+            # Verify error message
+            assert "Datenbankverbindung fehlgeschlagen" in blocker.args[0]
+    
+    def test_worker_unexpected_error(self, qapp, qtbot):
+        """Test handling of unexpected errors."""
+        worker = DownloadURLFetchWorker(
+            db_host="test.host",
+            db_name="test_db",
+            db_user="test_user",
+            db_password="test_pass"
+        )
+        
+        with patch('src.workers.download_url_fetch_worker.SumarioPMDClient') as mock_client_class:
+            mock_client_class.side_effect = RuntimeError("Unexpected error")
+            
+            # Connect signal spy
+            with qtbot.waitSignal(worker.error, timeout=2000) as blocker:
+                worker.run()
+            
+            # Verify error message
+            assert "Unerwarteter Fehler" in blocker.args[0]

--- a/tests/test_sumariopmd_download_urls.py
+++ b/tests/test_sumariopmd_download_urls.py
@@ -1,0 +1,183 @@
+"""Tests for SumarioPMDClient file/download-URL methods."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+import pymysql
+
+from src.db.sumariopmd_client import SumarioPMDClient, DatabaseError
+
+
+class TestFetchDownloadURLs:
+    """Tests for fetching download URLs from file table."""
+    
+    def test_fetch_download_urls_for_resource(self):
+        """Test fetching download URLs for a specific resource."""
+        client = SumarioPMDClient(
+            host="test.host",
+            database="test_db",
+            username="test_user",
+            password="test_pass"
+        )
+        
+        mock_files = [
+            {
+                'filename': 'data.zip',
+                'location': 'https://download.gfz.de/data.zip',
+                'format': 'ZIP',
+                'size': 1048576
+            },
+            {
+                'filename': 'metadata.xml',
+                'location': 'https://download.gfz.de/metadata.xml',
+                'format': 'XML',
+                'size': 2048
+            }
+        ]
+        
+        with patch.object(client, 'get_connection') as mock_conn:
+            mock_cursor = MagicMock()
+            mock_cursor.fetchall.return_value = mock_files
+            mock_conn.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
+            
+            files = client.fetch_download_urls_for_resource(123)
+            
+            assert len(files) == 2
+            assert files[0]['filename'] == 'data.zip'
+            assert files[0]['location'] == 'https://download.gfz.de/data.zip'
+            assert files[1]['filename'] == 'metadata.xml'
+    
+    def test_fetch_download_urls_empty_result(self):
+        """Test fetching download URLs when resource has no files."""
+        client = SumarioPMDClient(
+            host="test.host",
+            database="test_db",
+            username="test_user",
+            password="test_pass"
+        )
+        
+        with patch.object(client, 'get_connection') as mock_conn:
+            mock_cursor = MagicMock()
+            mock_cursor.fetchall.return_value = []
+            mock_conn.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
+            
+            files = client.fetch_download_urls_for_resource(999)
+            
+            assert len(files) == 0
+    
+    def test_fetch_download_urls_database_error(self):
+        """Test handling of database errors."""
+        client = SumarioPMDClient(
+            host="test.host",
+            database="test_db",
+            username="test_user",
+            password="test_pass"
+        )
+        
+        with patch.object(client, 'get_connection') as mock_conn:
+            mock_cursor = MagicMock()
+            mock_cursor.execute.side_effect = pymysql.Error("Connection lost")
+            mock_conn.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
+            
+            with pytest.raises(DatabaseError, match="Failed to fetch files"):
+                client.fetch_download_urls_for_resource(123)
+    
+    def test_fetch_all_dois_with_downloads(self):
+        """Test fetching all DOIs with download URLs."""
+        client = SumarioPMDClient(
+            host="test.host",
+            database="test_db",
+            username="test_user",
+            password="test_pass"
+        )
+        
+        mock_results = [
+            {
+                'doi': '10.5880/GFZ.1',
+                'filename': 'data.zip',
+                'download_url': 'https://download.gfz.de/data1.zip',
+                'format': 'ZIP',
+                'size': 1048576
+            },
+            {
+                'doi': '10.5880/GFZ.1',
+                'filename': 'metadata.xml',
+                'download_url': 'https://download.gfz.de/meta1.xml',
+                'format': 'XML',
+                'size': 2048
+            },
+            {
+                'doi': '10.5880/GFZ.2',
+                'filename': 'dataset.nc',
+                'download_url': 'https://download.gfz.de/data2.nc',
+                'format': 'NetCDF',
+                'size': 5242880
+            }
+        ]
+        
+        with patch.object(client, 'get_connection') as mock_conn:
+            mock_cursor = MagicMock()
+            mock_cursor.fetchall.return_value = mock_results
+            mock_conn.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
+            
+            dois_files = client.fetch_all_dois_with_downloads()
+            
+            assert len(dois_files) == 3
+            # First file for DOI 1
+            assert dois_files[0] == (
+                '10.5880/GFZ.1',
+                'data.zip',
+                'https://download.gfz.de/data1.zip',
+                'ZIP',
+                1048576
+            )
+            # Second file for DOI 1
+            assert dois_files[1] == (
+                '10.5880/GFZ.1',
+                'metadata.xml',
+                'https://download.gfz.de/meta1.xml',
+                'XML',
+                2048
+            )
+            # File for DOI 2
+            assert dois_files[2] == (
+                '10.5880/GFZ.2',
+                'dataset.nc',
+                'https://download.gfz.de/data2.nc',
+                'NetCDF',
+                5242880
+            )
+    
+    def test_fetch_all_dois_with_downloads_empty(self):
+        """Test fetching when no files exist."""
+        client = SumarioPMDClient(
+            host="test.host",
+            database="test_db",
+            username="test_user",
+            password="test_pass"
+        )
+        
+        with patch.object(client, 'get_connection') as mock_conn:
+            mock_cursor = MagicMock()
+            mock_cursor.fetchall.return_value = []
+            mock_conn.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
+            
+            dois_files = client.fetch_all_dois_with_downloads()
+            
+            assert len(dois_files) == 0
+    
+    def test_fetch_all_dois_with_downloads_database_error(self):
+        """Test handling of database errors in fetch_all."""
+        client = SumarioPMDClient(
+            host="test.host",
+            database="test_db",
+            username="test_user",
+            password="test_pass"
+        )
+        
+        with patch.object(client, 'get_connection') as mock_conn:
+            mock_cursor = MagicMock()
+            mock_cursor.execute.side_effect = pymysql.Error("Query timeout")
+            mock_conn.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
+            
+            with pytest.raises(DatabaseError, match="Failed to fetch DOIs with downloads"):
+                client.fetch_all_dois_with_downloads()

--- a/tests/test_sumariopmd_download_urls.py
+++ b/tests/test_sumariopmd_download_urls.py
@@ -95,6 +95,7 @@ class TestFetchDownloadURLs:
                 'doi': '10.5880/GFZ.1',
                 'filename': 'data.zip',
                 'download_url': 'https://download.gfz.de/data1.zip',
+                'description': 'Download data and description',
                 'format': 'ZIP',
                 'size': 1048576
             },
@@ -102,6 +103,7 @@ class TestFetchDownloadURLs:
                 'doi': '10.5880/GFZ.1',
                 'filename': 'metadata.xml',
                 'download_url': 'https://download.gfz.de/meta1.xml',
+                'description': 'Metadata file',
                 'format': 'XML',
                 'size': 2048
             },
@@ -109,6 +111,7 @@ class TestFetchDownloadURLs:
                 'doi': '10.5880/GFZ.2',
                 'filename': 'dataset.nc',
                 'download_url': 'https://download.gfz.de/data2.nc',
+                'description': 'NetCDF dataset',
                 'format': 'NetCDF',
                 'size': 5242880
             }
@@ -127,6 +130,7 @@ class TestFetchDownloadURLs:
                 '10.5880/GFZ.1',
                 'data.zip',
                 'https://download.gfz.de/data1.zip',
+                'Download data and description',
                 'ZIP',
                 1048576
             )
@@ -135,6 +139,7 @@ class TestFetchDownloadURLs:
                 '10.5880/GFZ.1',
                 'metadata.xml',
                 'https://download.gfz.de/meta1.xml',
+                'Metadata file',
                 'XML',
                 2048
             )
@@ -143,6 +148,7 @@ class TestFetchDownloadURLs:
                 '10.5880/GFZ.2',
                 'dataset.nc',
                 'https://download.gfz.de/data2.nc',
+                'NetCDF dataset',
                 'NetCDF',
                 5242880
             )


### PR DESCRIPTION
This pull request adds a new workflow for exporting DOIs with their associated download URLs from the database to a CSV file, including full UI integration, a threaded worker for fetching data, CSV export functionality, and comprehensive tests for the export logic. The changes are grouped into three main themes: database access, UI workflow, and CSV export/testing.

**Database access and worker integration:**

* Added two new methods to `SumarioPMDClient`: `fetch_download_urls_for_resource` (fetches download URLs for a single resource) and `fetch_all_dois_with_downloads` (fetches all DOIs with their file download URLs and metadata) in `src/db/sumariopmd_client.py`.
* Introduced a new threaded worker class `DownloadURLFetchWorker` in `src/workers/download_url_fetch_worker.py` to fetch DOIs and download URLs asynchronously, emitting progress, success, and error signals for UI updates.

**UI workflow enhancements:**

* Added a new "Download-URLs" group box and export button to the main window UI in `src/ui/main_window.py`, enabling users to start the export workflow.
* Implemented the complete UI logic for the export workflow: button click handler, credential checks, worker/thread setup, progress/error handling, CSV file dialog, and UI state management during export.
* Updated the window close event to properly handle cleanup of the download URL export thread if it is running, ensuring graceful shutdown.

**CSV export logic and testing:**

* Added a new function `export_dois_download_urls` to `src/utils/csv_exporter.py` for writing the fetched DOI/file data to CSV, with robust error handling for permissions, OS errors, and encoding.
* Created a comprehensive test suite in `tests/test_csv_export_download_urls.py` covering successful export, empty lists, special characters, large file sizes, multiple files per DOI, error scenarios, and UTF-8 encoding.