### PR TITLE
Fix coverage badge job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
-        pip install coverage-badge
+        pip install setuptools coverage-badge
     
     - name: Run tests and generate coverage
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
-        pip install setuptools coverage-badge
+        pip install coverage-badge
     
     - name: Run tests and generate coverage
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
   coverage-badge:
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.event_name == 'pull_request'
     permissions:
       contents: write  # Required to push coverage badge to repository
     

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.11'
     
     - name: Install system dependencies
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
   coverage-badge:
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'pull_request'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:
       contents: write  # Required to push coverage badge to repository
     


### PR DESCRIPTION
Dear @McNamara84,

after my last merge the coverage-badge job started to fail.
The reason is that the coverage-badge package still depends on pkg_resources, which is no longer available in Python 3.13 and therefore has to be provided by an older Python environment.

In this pull request, the problem is fixed by running the coverage-badge job with Python 3.11